### PR TITLE
splatmoji: copy data files properly (off by one)

### DIFF
--- a/splatmoji
+++ b/splatmoji
@@ -24,7 +24,7 @@ shift
 if [ $# -eq 0 ]; then
   datafiles=("${scriptdir}/data/*")
 else
-  datafiles="${@:2}"
+  datafiles="${@:1}"
 fi
 datafiles_list=$(IFS=$'\n'; echo "${datafiles[*]}")
 


### PR DESCRIPTION
`splatmoji copy data/example.tsv` will cause problems as it is off by one. 🙁 