### PR TITLE
Added new "copypaste" mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,24 @@
 Splatmoji
 =========
+- [Splatmoji](#splatmoji)
+- [Install](#install)
+- [Usage](#usage)
+    + [i3wm (Setting up shortcut)](#i3wm--setting-up-shortcut-)
+    + [Gnome](#gnome)
+- [Configuration](#configuration)
+  * [Recently-used selection](#recently-used-selection)
+  * [Paste-Shortcut-Key config (auto copy and paste)](#paste-shortcut-key-config--auto-copy-and-paste-)
+  * [Rofi config (the pop-up menu)](#rofi-config--the-pop-up-menu-)
+  * [Xsel config (copying to clipboard)](#xsel-config--copying-to-clipboard-)
+  * [Xdotool config (auto-typing)](#xdotool-config--auto-typing-)
+- [Updating emoji/emoticons](#updating-emoji-emoticons)
+  * [Emoji](#emoji)
+- [Emoticons](#emoticons)
+- [Custom Configuration and Custom Emoji/Emoticons](#custom-configuration-and-custom-emoji-emoticons)
+- [FAQ](#faq)
+- [Contributing](#contributing)
+- [Credits](#credits)
+- [License](#license)
 
 Quickly look up and input emoji and/or emoticons/kaomoji on your GNU/Linux desktop via pop-up menu.
 
@@ -65,9 +84,10 @@ Usage:
         omitted from the choice list.
 
   Positional arguments:
-    [copy|type]
-        This application can either place the final selection into the user's
-        clipboard (copy), or type it out for the user (type).
+    [copy|type|copypaste]
+        This application can place the final selection into the user's
+        clipboard (copy), type it out for the user (type), or place the final selection into the user's
+        clipboard and type it out for the user (copypaste).
 
     [FILE]...
         A list of files or directories of files to include in the display
@@ -78,6 +98,7 @@ Usage:
   Examples
     ./splatmoji copy
     ./splatmoji type
+    ./splatmoji copypaste
 
   Data files
     Splatmoji will by default try to combine data files from the following
@@ -99,7 +120,7 @@ Usage:
 
 You probably would want to bind this to some key combination in your window manager/desktop environment.
 
-### i3wm
+### i3wm (Setting up shortcut)
 
 ```sh
 # This would go into your .config/i3/config to bind to Super+slash
@@ -122,6 +143,7 @@ history_length=5
 rofi_command=rofi -dmenu -p '' -i -monitor -2
 xdotool_command=xdotool sleep 0.2 type --delay 100
 xsel_command=xsel -b -i
+paste_shortcut_keys=ctrl+v
 ```
 
 ## Recently-used selection
@@ -131,6 +153,19 @@ By default, Splatmoji will keep a list of the `${history_length}` most recently 
 Via the config file, you may either specify a preferred history file location or alter the number of recent entries that is displayed.
 
 To disable this feature entirely, just set `history_length` in the config file to `0`.
+
+## Paste-Shortcut-Key config (copy to clipboard and paste to current text field)
+
+You can change the shortcut keys to the one you have set on your system, in most case, it will be ctrl+v. It must be the shortcut keys that triggers the paste action in your computer or it will do nothing besides copying the emoji/kaomoji/emoticons.
+
+For the key combinations, check the xdotool manpage.
+
+```ini
+# You can also change to other combination that you have set on your system that triggers the "paste" action
+# paste-shortcut-keys example
+paste_shortcut_keys=ctrl+v
+```
+*Note that the copypaste mode does not work with most of the terminals, please paste it with ```ctrl+shift+v``` manually
 
 ## Rofi config (the pop-up menu)
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Requirements:
 * xsel (for putting your selection into the clipboard) (xclipboard also works)
 * jq (if JSON escaping is called for with the argument `--escape json`)
 
-To install the above required libraries, open your terminal and enter the following commands
+To install the required libraries above, open your terminal and enter the following commands
 
 ```sh
 # if you are using debian based distros (e.g. ubuntu)
@@ -166,7 +166,7 @@ Via the config file, you may either specify a preferred history file location or
 
 To disable this feature entirely, just set `history_length` in the config file to `0`.
 
-## Paste-Shortcut-Key config (copy to clipboard and paste to current text field)
+## Paste-Shortcut-Key config (copying to clipboard and paste to current text field)
 
 You can change the shortcut keys to the one you have set on your system, in most case, it will be ctrl+v. It must be the shortcut keys that triggers the paste action in your computer or it will do nothing besides copying the emoji/kaomoji/emoticons.
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 Splatmoji
 =========
-- [Splatmoji](#splatmoji)
 - [Install](#install)
 - [Usage](#usage)
-    + [i3wm (Setting up shortcut)](#i3wm--setting-up-shortcut-)
+  * [Setting up keyboard shortcut](#setting-up-keyboard-shortcut)
+    + [i3wm](#i3wm)
+    + [kde](#kde)
     + [Gnome](#gnome)
 - [Configuration](#configuration)
   * [Recently-used selection](#recently-used-selection)
-  * [Paste-Shortcut-Key config (auto copy and paste)](#paste-shortcut-key-config--auto-copy-and-paste-)
+  * [Paste-Shortcut-Key config (copy to clipboard and paste to current text field)](#paste-shortcut-key-config--copy-to-clipboard-and-paste-to-current-text-field-)
   * [Rofi config (the pop-up menu)](#rofi-config--the-pop-up-menu-)
   * [Xsel config (copying to clipboard)](#xsel-config--copying-to-clipboard-)
   * [Xdotool config (auto-typing)](#xdotool-config--auto-typing-)
@@ -120,12 +121,16 @@ Usage:
 
 You probably would want to bind this to some key combination in your window manager/desktop environment.
 
-### i3wm (Setting up shortcut)
+## Setting up keyboard shortcut
+### i3wm 
 
 ```sh
 # This would go into your .config/i3/config to bind to Super+slash
 bindsym $mod+slash exec "/path/to/the/script type"
 ```
+
+### kde
+[This Gnome.org help page](https://docs.kde.org/trunk5/en/kde-workspace/kcontrol/khotkeys/index.html) seems to outline how to do this in the popular Gnome desktop environment.
 
 ### Gnome
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,15 @@ Requirements:
 * xsel (for putting your selection into the clipboard) (xclipboard also works)
 * jq (if JSON escaping is called for with the argument `--escape json`)
 
+To install the above required libraries, open your terminal and enter the following commands
+
 ```sh
-# sudo apt-get install rofi xdotool xsel || sudo yum install rofi xdotool xsel
+# if you are using debian based distros (e.g. ubuntu)
+sudo apt-get install rofi xdotool xsel
+# if your distro is using yum package manager
+yum install rofi xdotool xsel
+
+# After you have installed the required packages, clone the repository
 git clone https://github.com/cspeterson/splatmoji.git
 ```
 
@@ -130,7 +137,7 @@ bindsym $mod+slash exec "/path/to/the/script type"
 ```
 
 ### kde
-[This Gnome.org help page](https://docs.kde.org/trunk5/en/kde-workspace/kcontrol/khotkeys/index.html) seems to outline how to do this in the popular Gnome desktop environment.
+[This kde.org help page](https://docs.kde.org/trunk5/en/kde-workspace/kcontrol/khotkeys/index.html) seems to outline how to do this in the popular Gnome desktop environment.
 
 ### Gnome
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ bindsym $mod+slash exec "/path/to/the/script type"
 ```
 
 ### kde
-[This kde.org help page](https://docs.kde.org/trunk5/en/kde-workspace/kcontrol/khotkeys/index.html) seems to outline how to do this in the popular Gnome desktop environment.
+[This kde.org help page](https://docs.kde.org/trunk5/en/kde-workspace/kcontrol/khotkeys/index.html) seems to outline how to do this in the popular kde desktop environment.
 
 ### Gnome
 

--- a/lib/functions
+++ b/lib/functions
@@ -314,6 +314,21 @@ output_copied() {
   echo -n "${selection}" | eval "${output_command}"
 }
 
+output_copypasted() {
+  # Results finally to clipboard
+  #
+  # $1: command line to eval for output method
+  # $2: user selection to output
+
+  output_command="${1}"
+  selection="${2}"
+  paste_shortcut_keys="${3}"
+
+  echo -n "${selection}" | eval "${output_command}"
+  
+  eval "xdotool key ${paste_shortcut_keys}"
+}
+
 output_typed() {
   # Results finally typed
   #
@@ -415,7 +430,7 @@ parse_args() {
   shift $(( OPTIND - 1 ))
   # Get subcommand and positional arguments
   readonly SUBCOMMAND="${1}"
-  if [ "${SUBCOMMAND}" != 'type' ] && [ "${SUBCOMMAND}" != 'copy' ]; then
+  if [ "${SUBCOMMAND}" != 'type' ] && [ "${SUBCOMMAND}" != 'copy' ] && [ "${SUBCOMMAND}" != 'copypaste' ]; then
     echo 'Error: [copy|type] is required.' >&2
     echo
     print_help
@@ -428,7 +443,7 @@ parse_args() {
 print_help() {
   echo 'Usage:'
   echo "
-  ${PROGNAME} [OPTIONS]... [copy|type] [FILE]...
+  ${PROGNAME} [OPTIONS]... [copy|type|copypaste] [FILE]...
 
   Quickly look up and input emoji and/or emoticons/kaomoji on your GNU/Linux
   desktop via pop-up menu.
@@ -470,9 +485,10 @@ print_help() {
           * user selection escaping
 
   Positional arguments:
-    [copy|type]
-        This application can either place the final selection into the user's
-        clipboard (copy), or type it out for the user (type).
+    [copy|type|copypaste]
+        This application can place the final selection into the user's
+        clipboard (copy), type it out for the user (type), or place the final selection into the user's
+        clipboard and type it out for the user (copypaste).
 
     [FILE]...
         A list of files or directories of files to include in the display
@@ -483,6 +499,7 @@ print_help() {
   Examples
     ${PROGNAME} copy
     ${PROGNAME} type
+    ${PROGNAME} copypaste
 
   Data files
     Splatmoji will by default try to combine data files from the following

--- a/splatmoji
+++ b/splatmoji
@@ -92,8 +92,10 @@ main() {
 
   if [ "${SUBCOMMAND}" == 'type' ]; then
     output_typed "${config[xdotool_command]}" "${selection}"
-  else
+  elif [ "${SUBCOMMAND}" == 'copy' ]; then
     output_copied "${config[xsel_command]}" "${selection}"
+  else
+    output_copypasted "${config[xsel_command]}" "${selection}" "${config[paste_shortcut_keys]}"
   fi
 }
 

--- a/splatmoji.config
+++ b/splatmoji.config
@@ -1,5 +1,6 @@
 # history_file=~/.local/state/splatmoji/history
 history_length=5
 rofi_command=rofi -dmenu -p '' -i -monitor -2
-xdotool_command=xdotool sleep 0.2 type --delay 100
+xdotool_command=xdotool type 
 xsel_command=xsel -b -i
+paste_shortcut_keys=ctrl+v

--- a/splatmoji.config
+++ b/splatmoji.config
@@ -1,6 +1,6 @@
 # history_file=~/.local/state/splatmoji/history
 history_length=5
 rofi_command=rofi -dmenu -p '' -i -monitor -2
-xdotool_command=xdotool type 
+xdotool_command=xdotool sleep 0.2 type --delay 100
 xsel_command=xsel -b -i
 paste_shortcut_keys=ctrl+v


### PR DESCRIPTION
Added new mode as an option to deal with the slow-typing issue in type mode, updates with readme.md and added TOC to it.

I am using kde and I have noticed that the type mode is really slow when it is dealing with non-ascii character, see this: https://i.imgur.com/BOiNAeO.gifv

This is just really annoying when chatting with someone using keyboard, I have to wait until it is done and finally I can type my things. Although you can just use the copy mode and paste it yourself, but I think the copypaste mode will just do things faster, see the gif for example: https://i.imgur.com/zOFe8uA.gifv

Some minor changes with the readme.md files and added Table of contents to it so it will be easier for linux beginners and faster navigation between different sections.